### PR TITLE
Fix iOS feed configuration button by adding proper verification callb…

### DIFF
--- a/ch.alienlebarge.miniflux/ui-config.json
+++ b/ch.alienlebarge.miniflux/ui-config.json
@@ -27,7 +27,7 @@
       "name": "limit",
       "type": "number",
       "prompt": "Number of articles to fetch",
-      "default": 50
+      "value": "50"
     }
   ]
 }


### PR DESCRIPTION
…acks

The "Add Feed" button remained disabled on iOS because the verify() function wasn't communicating verification status to Tapestry.

Changes:
- Add field validation for required inputs (site, username, password)
- Call processVerification() on successful authentication
- Call processError() with user-friendly messages on failure
- Fix ui-config.json to use "value" instead of "default" for limit field
- Display username in feed name when available

Fixes #5