### PR TITLE
Simplify iOS configuration handling

### DIFF
--- a/ch.alienlebarge.miniflux/plugin.js
+++ b/ch.alienlebarge.miniflux/plugin.js
@@ -144,21 +144,14 @@ function handleError(error) {
  */
 function verify() {
     console.log("Verifying Miniflux connection...");
+    console.log("Site: " + (site || "(empty)"));
+    console.log("Username: " + (username || "(empty)"));
+    console.log("Password: " + (password ? "(provided)" : "(empty)"));
 
-    // Validate required fields - but don't call processError for missing fields
-    // as verify() may be called before all fields are filled (especially on iOS)
-    if (!site || site.trim() === "") {
-        console.log("Site URL is not filled yet");
-        return Promise.resolve();
-    }
-
-    if (!username || username.trim() === "") {
-        console.log("Username is not filled yet");
-        return Promise.resolve();
-    }
-
-    if (!password || password.trim() === "") {
-        console.log("Password is not filled yet");
+    // Skip verification if critical fields are missing
+    // On iOS, verify() may be called as user types, so we return early without signaling
+    if (!site || !username || !password) {
+        console.log("Skipping verification - fields not yet complete");
         return Promise.resolve();
     }
 

--- a/ch.alienlebarge.miniflux/ui-config.json
+++ b/ch.alienlebarge.miniflux/ui-config.json
@@ -4,7 +4,6 @@
       "name": "site",
       "type": "url",
       "prompt": "Miniflux Instance URL",
-      "validate_as": "url",
       "placeholder": "https://your-instance.miniflux.app"
     },
     {


### PR DESCRIPTION
Changes:
1. Remove redundant "validate_as": "url" from site field in ui-config.json
   - The "type": "url" already provides validation
   - Redundant validation may confuse iOS UI

2. Simplify verify() field validation logic
   - Combine all field checks into single condition
   - Add debug logging to track field states
   - Clearer logic for when verification is skipped

These changes aim to fix the issue where only the "Site" field appears visible on iOS and the "Add Feed" button remains disabled.