### PR TITLE
Add Miniflux icon to connector

### DIFF
--- a/ch.alienlebarge.miniflux/plugin-config.json
+++ b/ch.alienlebarge.miniflux/plugin-config.json
@@ -1,6 +1,7 @@
 {
   "id": "ch.alienlebarge.miniflux",
   "display_name": "Miniflux",
+  "icon": "https://raw.githubusercontent.com/miniflux/logo/master/icon.svg",
   "site_prompt": "Miniflux Instance URL",
   "site_placeholder": "https://your-instance.miniflux.app",
   "needs_verification": true,


### PR DESCRIPTION
## Summary
- Add the official Miniflux logo to the connector configuration
- Uses the SVG icon from the official Miniflux logo repository

## Changes
- Updated `plugin-config.json` to include the `icon` field with the URL to the Miniflux logo

## Test plan
- [ ] Load the connector in Tapestry Loom (Cmd-R)
- [ ] Verify the icon appears in the connector panel
- [ ] Confirm the icon displays correctly

## Related
Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)