### PR TITLE
Use Apple Touch Icon for avatars

### DIFF
--- a/ch.alienlebarge.miniflux/plugin.js
+++ b/ch.alienlebarge.miniflux/plugin.js
@@ -73,10 +73,10 @@ function convertEntryToItem(entry) {
     if (entry.feed && entry.feed.title) {
         var author = Identity.createWithName(entry.feed.title);
 
-        // Add feed favicon as avatar using Google Favicons service (returns PNG)
+        // Add feed Apple Touch Icon as avatar (high quality PNG)
         if (entry.feed.site_url) {
-            var domain = entry.feed.site_url.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
-            author.avatar = "https://www.google.com/s2/favicons?domain=" + domain + "&sz=128";
+            var baseUrl = entry.feed.site_url.replace(/\/$/, "");
+            author.avatar = baseUrl + "/apple-touch-icon.png";
         }
 
         item.author = author;


### PR DESCRIPTION
## Summary
- Use Apple Touch Icon (`/apple-touch-icon.png`) for feed avatars
- Apple Touch Icons are high quality PNG images (typically 180x180)

## Changes
- Updated `plugin.js` to use `{site_url}/apple-touch-icon.png` as avatar

## Note
Not all sites have an Apple Touch Icon. If the icon doesn't exist, the avatar won't display for that feed.

## Test plan
- [ ] Load the connector in Tapestry Loom (Cmd-R)
- [ ] Verify Apple Touch Icons display correctly in the timeline
- [ ] Check feeds from various sources to confirm compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)