### PR TITLE
feat: support enclosures as media attachments

### DIFF
--- a/ch.alienlebarge.miniflux/plugin.js
+++ b/ch.alienlebarge.miniflux/plugin.js
@@ -161,6 +161,22 @@ function convertEntryToItem(entry, iconMap) {
 
     item.actions = actions;
 
+    // Add media attachments from enclosures (images, audio, video)
+    if (entry.enclosures && entry.enclosures.length > 0) {
+        var attachments = [];
+        for (var j = 0; j < entry.enclosures.length; j++) {
+            var enclosure = entry.enclosures[j];
+            if (enclosure.url && enclosure.mime_type) {
+                var attachment = MediaAttachment.createWithUrl(enclosure.url);
+                attachment.mimeType = enclosure.mime_type;
+                attachments.push(attachment);
+            }
+        }
+        if (attachments.length > 0) {
+            item.attachments = attachments;
+        }
+    }
+
     return item;
 }
 


### PR DESCRIPTION
## Summary
- Convert Miniflux entry enclosures (images, audio, video) to Tapestry `MediaAttachment` objects
- Keeps `provides_attachments: false` so Tapestry continues to auto-generate image previews from body HTML
- Only creates attachments when enclosure has both `url` and `mime_type`

Closes #26

## Test plan
- [ ] Reload connector in Tapestry Loom (Cmd-R)
- [ ] Verify articles with enclosures (e.g. podcasts) show media inline
- [ ] Verify articles without enclosures still show auto-generated image previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)