### PR TITLE
refactor: update to latest Tapestry API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,12 @@ if (entry.feed && entry.feed.title) {
     }
 
     item.source = source;
+
+    // Add category as annotation if available
+    if (entry.feed.category && entry.feed.category.title) {
+        var annotation = Annotation.createWithText(entry.feed.category.title);
+        item.annotations = [annotation];
+    }
 }
 
 // Add actions using actions dictionary
@@ -153,9 +159,11 @@ if (entry.enclosures && entry.enclosures.length > 0) {
 - Variables from `ui-config.json` are pre-populated as global variables
 - Use `Item.createWithUriDate(uri, date)` to create timeline items
 - Use `Identity.createWithName(name)` to create author/source objects
+- Use `Annotation.createWithText(text)` to attach contextual metadata (e.g. categories) to items via `item.annotations`
 - Call `processResults(items)` to return items from `load()`
 - Call `processVerification(config)` to signal successful verification
 - Call `processError(message)` to signal errors
+- Call `actionComplete(item, null)` after a successful action (two arguments required per v1.4+)
 
 ## Development Workflow
 
@@ -220,7 +228,7 @@ Check your current branch with `git branch --show-current` before making changes
 - **Item Style**: Uses `"post"` style in `plugin-config.json` for better timeline presentation
 - **Feed Favicon**: Displays feed favicons as author avatars using DuckDuckGo icon service
 - **Author Display**: Shows feed name as author (not article author) for better feed recognition
-- **Category Support**: Displays Miniflux categories when available
+- **Category Support**: Displays Miniflux categories as `Annotation` objects
 
 ### Performance Optimizations
 - **Adaptive Time Window**: Uses smart time filtering (7 days on first load, 4 hours on subsequent loads)

--- a/ch.alienlebarge.miniflux/README.md
+++ b/ch.alienlebarge.miniflux/README.md
@@ -59,7 +59,7 @@ If you have the `ch.alienlebarge.miniflux.tapestry` file:
 
 - **Number of articles to fetch**: Maximum number of unread articles to retrieve
   - Default: 500
-  - Note: Only articles from the last 30 days are fetched for performance
+  - Note: On first load, articles from the last 7 days are fetched. Subsequent loads look back 4 hours to capture changes made on other devices.
 
 ## How It Works
 
@@ -82,7 +82,7 @@ Each article displays:
 
 - **Title**: The article headline
 - **Date**: Publication date
-- **Author**: Article author (if available)
+- **Author**: The RSS feed name (with favicon)
 - **Content**: Full HTML content from the feed
 - **Source**: The RSS feed name and website
 - **Category**: The Miniflux category (if assigned)
@@ -129,7 +129,8 @@ This connector uses the following Miniflux API endpoints:
 
 - `GET /v1/me` - Verify authentication
 - `GET /v1/entries` - Fetch unread articles (supports `category_id` filter)
-- `PUT /v1/entries` - Mark articles as read
+- `PUT /v1/entries` - Mark articles as read or unread
+- `PUT /v1/entries/{id}/bookmark` - Toggle star/bookmark status
 
 For more information, see the [Miniflux API Documentation](https://miniflux.app/docs/api.html).
 
@@ -176,9 +177,12 @@ For issues or questions:
 
 ## Version History
 
-### Development (In Progress)
+### Latest
 
-- X-Auth-Token authentication with API token
-- Fetch unread articles
-- Mark as read action
+- Categories displayed as annotations
+- Star/Unstar (bookmark) action
+- Feed favicons as author avatars (native Miniflux icons + DuckDuckGo fallback)
+- Adaptive time window (7 days on first load, 4 hours on subsequent loads)
+- Mark as Read / Mark as Unread toggle
 - Full HTML content support
+- X-Auth-Token authentication with API token

--- a/ch.alienlebarge.miniflux/plugin.js
+++ b/ch.alienlebarge.miniflux/plugin.js
@@ -130,9 +130,10 @@ function convertEntryToItem(entry, iconMap) {
 
         item.source = source;
 
-        // Add category if available
+        // Add category as annotation if available
         if (entry.feed.category && entry.feed.category.title) {
-            item.category = entry.feed.category.title;
+            var annotation = Annotation.createWithText(entry.feed.category.title);
+            item.annotations = [annotation];
         }
     }
 
@@ -427,7 +428,7 @@ function performAction(actionId, actionValue, item) {
                 newActions["unstar"] = actionValue;
             }
             item.actions = newActions;
-            actionComplete(item);
+            actionComplete(item, null);
 
             return response;
         })
@@ -466,7 +467,7 @@ function performAction(actionId, actionValue, item) {
                 newActions["mark_as_unread"] = actionValue;
             }
             item.actions = newActions;
-            actionComplete(item);
+            actionComplete(item, null);
 
             return response;
         })


### PR DESCRIPTION
## Summary

- Replace `item.category` (undocumented property) with `Annotation.createWithText()` — the standard Tapestry API for attaching contextual metadata to items
- Fix `actionComplete()` signature: add missing second argument `null` per v1.4+ spec (`actionComplete(results, error)`)
- Update `CLAUDE.md` and `README.md` to reflect these changes and fix several inaccuracies (time window, author description, missing API endpoint)

## Test plan

- [ ] Verify that Miniflux categories appear as annotations in Tapestry
- [ ] Verify that "Mark as Read / Unread" still works correctly
- [ ] Verify that "Star / Unstar" still works correctly

https://claude.ai/code/session_0193g2xffN5qSPWFMhh2oY6x